### PR TITLE
update report_pc() to include effect sizes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: statsreportr
 Title: Report Formated Statistical Tests In Rmd or qmd Documents
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: 
     person("Kyle", "Roddick", , "kyle.roddick@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2701-8166"))
 Description: Convenience functions to make reporting the results of 'rstatix'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # statsreportr (development version)
 
+# statsreportr 0.0.0.9004
+
+* `report_pc()` now is able to report effect sizes for pairwise comparisons. The effect size is calculated using the `emmeans::eff_size()` function.
+
 # statsreportr 0.0.0.9003
 
 * `cor_test()` and `report_cor()` added to the package. These functions are used to report the results of correlation tests. `cor_test()` is modified version of `rstatix::cor_test()` that will save the degrees of freedom of a Pearson correlation in the output, and `report_cor()` formats the results for reporting in R Markdown and Quarto documents.

--- a/R/report_pc.R
+++ b/R/report_pc.R
@@ -79,7 +79,7 @@ report_pc <- function(
   }
 
   if (effect_size) {
-    formula_ef <- formula(paste(
+    formula_ef <- stats::formula(paste(
       pairwise_comparison$.y.[effect],
       "~",
       pairwise_comparison$term[effect]
@@ -96,7 +96,7 @@ report_pc <- function(
     )
     data_ef <- data_ef[rows_ef, ]
 
-    lm_ef <- lm(formula_ef, data_ef)
+    lm_ef <- stats::lm(formula_ef, data_ef)
     em_ef <- emmeans::emmeans(
       lm_ef,
       pairwise_comparison$term[effect],

--- a/R/report_pc.R
+++ b/R/report_pc.R
@@ -3,6 +3,7 @@
 #' @param pairwise_comparison an rstatix::emmeans_test object
 #' @param effect The names or row number of the effect to report
 #' @param digits The number of digits to round the p value to
+#' @param effect_size Whether to include the effect size in the report
 #'
 #' @returns A string with the formatted pairwise comparison result for use inline in an R Markdown or Quarto document
 #' @export
@@ -22,7 +23,8 @@
 report_pc <- function(
   pairwise_comparison,
   effect = 1,
-  digits = 3
+  digits = 3,
+  effect_size = TRUE
 ) {
   if (
     !("rstatix_test" %in% attributes(pairwise_comparison)$class) |
@@ -73,6 +75,49 @@ report_pc <- function(
     p_report <- stringr::str_c(
       ", adjusted *p* ",
       format_p(p_value, digits = digits)
+    )
+  }
+
+  if (effect_size) {
+    formula_ef <- formula(paste(
+      pairwise_comparison$.y.[effect],
+      "~",
+      pairwise_comparison$term[effect]
+    ))
+    data_ef <- attributes(pairwise_comparison)$args$data
+
+    y_ef <- which(colnames(data_ef) == pairwise_comparison$term[effect])
+    rows_ef <- which(
+      data_ef[, y_ef] %in%
+        c(
+          pairwise_comparison$group1[effect],
+          pairwise_comparison$group2[effect]
+        )
+    )
+    data_ef <- data_ef[rows_ef, ]
+
+    lm_ef <- lm(formula_ef, data_ef)
+    em_ef <- emmeans::emmeans(
+      lm_ef,
+      pairwise_comparison$term[effect],
+      adjust = attributes(pairwise_comparison)$args$p.adjust.method
+    )
+
+    ef_size <- emmeans::eff_size(
+      em_ef,
+      sigma = stats::sigma(lm_ef),
+      edf = pairwise_comparison$df[effect]
+    )
+
+    ef_size <- format(
+      summary(ef_size)$effect.size,
+      digits = digits
+    )
+
+    p_report <- stringr::str_c(
+      p_report,
+      ", *d* = ",
+      ef_size
     )
   }
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -80,7 +80,7 @@ mtcars |> report_mean_sem(mpg, cyl, effect = "6")
 The intent of this package is to be used inline in a R Markdown or Quarto document. For example, the following inline code:
 
 > ```{block, eval = FALSE}
-The results of the t test showed a significant difference in the mpg of 6 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "6")`\`) vs 8 ((\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`)) cylinder cars (\``r report_t(results4, effect = c("6", "8"), cohensd = cohensd4, cohens_magnitude = TRUE)`\`). 
+The results of the t test showed a significant difference in the mpg of 6 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "6")`\`) vs 8 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`) cylinder cars (\``r report_t(results4, effect = c("6", "8"), cohensd = cohensd4, cohens_magnitude = TRUE)`\`). 
 > ```
 
 Will render as:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Quarto document. For example, the following inline code:
 
 > The results of the t test showed a significant difference in the mpg
 > of 6 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "6")`\`) vs 8
-> ((\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`)) cylinder
+> (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`) cylinder
 > cars
 > (\``r report_t(results4, effect = c("6", "8"), cohensd = cohensd4, cohens_magnitude = TRUE)`\`).
 

--- a/man/report_pc.Rd
+++ b/man/report_pc.Rd
@@ -4,7 +4,7 @@
 \alias{report_pc}
 \title{Report a pairwise comparison result in text}
 \usage{
-report_pc(pairwise_comparison, effect = 1, digits = 3)
+report_pc(pairwise_comparison, effect = 1, digits = 3, effect_size = TRUE)
 }
 \arguments{
 \item{pairwise_comparison}{an rstatix::emmeans_test object}
@@ -12,6 +12,8 @@ report_pc(pairwise_comparison, effect = 1, digits = 3)
 \item{effect}{The names or row number of the effect to report}
 
 \item{digits}{The number of digits to round the p value to}
+
+\item{effect_size}{Whether to include the effect size in the report}
 }
 \value{
 A string with the formatted pairwise comparison result for use inline in an R Markdown or Quarto document

--- a/tests/testthat/test-report_pc.R
+++ b/tests/testthat/test-report_pc.R
@@ -3,12 +3,17 @@ test_that("report_pc works", {
   results2 <- rstatix::emmeans_test(mtcars, mpg ~ am, p.adjust.method = "none")
 
   expect_equal(
-    report_pc(results),
+    report_pc(results, effect_size = FALSE),
     "*t*~(29)~ = 4.44, adjusted *p* < 0.001"
   )
 
   expect_equal(
-    report_pc(results2),
+    report_pc(results, effect_size = TRUE),
+    "*t*~(29)~ = 4.44, adjusted *p* < 0.001, *d* = 1.88"
+  )
+
+  expect_equal(
+    report_pc(results2, effect_size = FALSE),
     "*t*~(30)~ = -4.11, *p* < 0.001"
   )
 })
@@ -17,7 +22,7 @@ test_that("report_pc accepts numeric effect argument", {
   results <- rstatix::emmeans_test(mtcars, mpg ~ cyl)
 
   expect_equal(
-    report_pc(results, 2),
+    report_pc(results, 2, effect_size = FALSE),
     "*t*~(29)~ = 8.9, adjusted *p* < 0.0001"
   )
 })
@@ -26,7 +31,7 @@ test_that("report_pc accepts string effect argument", {
   results <- rstatix::emmeans_test(mtcars, mpg ~ cyl)
 
   expect_equal(
-    report_pc(results, c("4", "6")),
+    report_pc(results, c("4", "6"), effect_size = FALSE),
     "*t*~(29)~ = 4.44, adjusted *p* < 0.001"
   )
 })
@@ -35,12 +40,12 @@ test_that("report_pc accepts digits argument", {
   results <- rstatix::emmeans_test(mtcars, mpg ~ cyl)
 
   expect_equal(
-    report_pc(results, 2, digits = 1),
+    report_pc(results, 2, digits = 1, effect_size = FALSE),
     "*t*~(29)~ = 9, adjusted *p* < 0.0001"
   )
 
   expect_error(
-    report_pc(results, 2, digits = "test"),
+    report_pc(results, 2, digits = "test", effect_size = FALSE),
     "The digits argument must be a number"
   )
 })

--- a/vignettes/statsreportr.Rmd
+++ b/vignettes/statsreportr.Rmd
@@ -77,7 +77,7 @@ mtcars |> report_mean_sem(mpg, cyl, effect = "6")
 When used with inline code in a R Markdown or Quarto document, the following inline code:
 
 > ```{block, eval = FALSE}
-The results of the t test showed a significant difference in the mpg of 6 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "6")`\`) vs 8 ((\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`)) cylinder cars (\``r report_t(results4, effect = c("6", "8"), cohensd = cohensd4, cohens_magnitude = TRUE)`\`). 
+The results of the t test showed a significant difference in the mpg of 6 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "6")`\`) vs 8 (\``r mtcars |> report_mean_sd(mpg, cyl, effect = "8")`\`) cylinder cars (\``r report_t(results4, effect = c("6", "8"), cohensd = cohensd4, cohens_magnitude = TRUE)`\`). 
 > ```
 
 Will render as:


### PR DESCRIPTION
This pull request introduces a new feature to the `report_pc()` function, enabling it to report effect sizes for pairwise comparisons. Additionally, it includes updates to documentation, tests, and examples to support this feature. Minor corrections to inline code examples are also included.

### New Feature: Effect Size Reporting in `report_pc()`
* Added a new `effect_size` parameter to the `report_pc()` function, defaulting to `TRUE`, allowing users to include effect size in the report. The effect size is calculated using the `emmeans::eff_size()` function. (`R/report_pc.R`: [[1]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242R6) [[2]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242L25-R27) [[3]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242R81-R123)
* Updated the function's documentation to reflect the new parameter. (`man/report_pc.Rd`: [man/report_pc.RdL7-R16](diffhunk://#diff-b43e1337307e766bbe015058ea911240bc9956ba1b8fd676e385d2879ea2ff0bL7-R16))

### Documentation Updates
* Incremented the package version to `0.0.0.9004` in the `DESCRIPTION` file. (`DESCRIPTION`: [DESCRIPTIONL3-R3](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3))
* Added a changelog entry in `NEWS.md` describing the new feature. (`NEWS.md`: [NEWS.mdR3-R6](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR3-R6))

### Test Suite Enhancements
* Updated test cases for `report_pc()` to validate the new `effect_size` parameter, ensuring correct behavior when it is enabled or disabled. (`tests/testthat/test-report_pc.R`: [[1]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9L6-R16) [[2]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9L20-R25) [[3]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9L29-R34) [[4]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9L38-R48)

### Minor Fixes
* Corrected formatting in inline code examples in `README.Rmd`, `README.md`, and `vignettes/statsreportr.Rmd` to remove duplicate parentheses. (`README.Rmd`: [[1]](diffhunk://#diff-72778b58969c8ca8268402860b0e003e3d213a26c812bc9f9b928395c284c99fL83-R83) `README.md`: [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L88-R88) `vignettes/statsreportr.Rmd`: [[3]](diffhunk://#diff-e873e0e3f69fe87687b6a126380014f55fc6baebe82cd841dfa6fa46a887ead6L80-R80)