### PR TITLE
report_pc() now uses order of named effects to determine sign of effect size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: statsreportr
 Title: Report Formated Statistical Tests In Rmd or qmd Documents
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     person("Kyle", "Roddick", , "kyle.roddick@gmail.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-2701-8166"))
 Description: Convenience functions to make reporting the results of 'rstatix'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # statsreportr (development version)
 
+# statsreportr 0.0.0.9006
+
+* `report_pc()` now takes into consideration the order of named `effect` argument to determine the direction of the effect size in the output.
+
 # statsreportr 0.0.0.9005
 
 * `report_pc()` fixed bug in data selection during effect size calculation.

--- a/tests/testthat/test-report_pc.R
+++ b/tests/testthat/test-report_pc.R
@@ -1,6 +1,9 @@
 test_that("report_pc works", {
   results <- rstatix::emmeans_test(mtcars, mpg ~ cyl)
   results2 <- rstatix::emmeans_test(mtcars, mpg ~ am, p.adjust.method = "none")
+  results3 <- mtcars |>
+    dplyr::mutate(test = rep(c("a", "b"), each = 16)) |>
+    rstatix::emmeans_test(mpg ~ test, p.adjust.method = "none")
 
   expect_equal(
     report_pc(results, effect_size = FALSE),
@@ -13,8 +16,23 @@ test_that("report_pc works", {
   )
 
   expect_equal(
+    report_pc(results, effect = c("4", "6")),
+    "*t*~(29)~ = 4.44, adjusted *p* < 0.001, *d* = 1.88"
+  )
+
+  expect_equal(
+    report_pc(results, effect = c("6", "4")),
+    "*t*~(29)~ = 4.44, adjusted *p* < 0.001, *d* = -1.88"
+  )
+
+  expect_equal(
     report_pc(results2, effect_size = FALSE),
     "*t*~(30)~ = -4.11, *p* < 0.001"
+  )
+
+  expect_equal(
+    report_pc(results3),
+    "*t*~(30)~ = -1.84, *p* = 0.075, *d* = -0.651"
   )
 })
 
@@ -73,5 +91,25 @@ test_that("report_pc throws errors with incorrect input", {
   expect_error(
     report_pc(results, 100),
     "The effect number is greater than the number of effects in the emmeans_test table"
+  )
+
+  expect_error(
+    report_pc(results, -1),
+    "The effect number must be greater than 0"
+  )
+
+  expect_error(
+    report_pc(results, TRUE),
+    "The effect must be a single numeric value or a vector of length 2 corresponding to the group1 and group2 columns in the emmeans test"
+  )
+
+  expect_error(
+    report_pc(results, 1:3),
+    "The effect must be a single numeric value or a vector of length 2 corresponding to the group1 and group2 columns in the emmeans test"
+  )
+
+  expect_error(
+    report_pc(results, effect_size = "test"),
+    "The effect_size argument must be TRUE or FALSE"
   )
 })


### PR DESCRIPTION
This pull request introduces enhancements to the `report_pc()` function, focusing on improving its flexibility and robustness. Key changes include adding support for determining the direction of effect sizes based on the order of the `effect` argument, introducing stricter input validation, and expanding test coverage to ensure reliability.

### Enhancements to `report_pc()` functionality:
* The `effect` argument now supports determining the direction of the effect size based on the order of the named groups provided. If the order is reversed, the effect size is negated to reflect the correct direction. (`R/report_pc.R`, [[1]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242R38-R104) [[2]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242L83-R178)
* A new `reverse_effect_size` flag has been added to handle reversed group orders, ensuring accurate effect size calculations. (`R/report_pc.R`, [R/report_pc.RL83-R178](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242L83-R178))

### Input validation improvements:
* Added validation to ensure the `effect_size` argument is a logical value (`TRUE` or `FALSE`). (`R/report_pc.R`, [R/report_pc.RR38-R104](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242R38-R104))
* Enhanced error handling for the `effect` argument, ensuring it is either a single numeric value or a vector of length 2, and added checks for invalid numeric values (e.g., negative or out-of-range indices). (`R/report_pc.R`, [[1]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242R38-R104) [[2]](diffhunk://#diff-143b62f4992111080c19eb88d58afcfe0ed49b97badb1b53e3f5e72f8cc76242L127-R191)

### Test suite updates:
* Expanded test cases to verify the behavior of `report_pc()` with reversed group orders, numeric and character `effect` arguments, and new scenarios for effect size calculations. (`tests/testthat/test-report_pc.R`, [[1]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9R4-R6) [[2]](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9R18-R36)
* Added tests to ensure proper error messages are raised for invalid inputs, such as incorrect `effect` or `effect_size` values. (`tests/testthat/test-report_pc.R`, [tests/testthat/test-report_pc.RR95-R114](diffhunk://#diff-fc13e5b7af22f76c5fe465bbf2f57585b201481c4f1358bf3c492b31b32fa7a9R95-R114))

### Documentation and versioning:
* Updated the package version to `0.0.0.9006` to reflect these changes. (`DESCRIPTION`, [DESCRIPTIONL3-R3](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL3-R3))
* Documented the new behavior of `report_pc()` in the `NEWS.md` file. (`NEWS.md`, [NEWS.mdR3-R6](diffhunk://#diff-51920e95310ebfbc1ae31709f3b95f89afffbf4f1a6e38e8b2b406e2fb6197eaR3-R6))