### PR TITLE
Initial use of jarl

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^pkgdown$
 .air.toml
 codecov.yml
+jarl.toml

--- a/R/cor_test.R
+++ b/R/cor_test.R
@@ -203,10 +203,10 @@ as_tidy_stat <- function(x, round.p = TRUE, digits = 3, stat.method = NULL) {
     alternative <- p <- parameter <- .data <- NULL
   res <- broom::tidy(x)
   if (!is.null(stat.method)) {
-    res |> dplyr::mutate(method = stat.method) -> res
+    res <- res |> dplyr::mutate(method = stat.method)
   } else if ("method" %in% colnames(res)) {
     stat.method <- get_stat_method(x)
-    res |> dplyr::mutate(method = stat.method) -> res
+    res <- res |> dplyr::mutate(method = stat.method)
   }
   if ("p.value" %in% colnames(res)) {
     res <- res |>

--- a/R/format_p.R
+++ b/R/format_p.R
@@ -13,11 +13,11 @@ format_p <- function(p_value, digits = 3) {
   stopifnot(is.numeric(p_value), length(p_value) == 1)
 
   dplyr::case_when(
-    p_value > .1 ~ stringr::str_c("= ", round(p_value, digits)),
-    p_value > .05 ~ stringr::str_c("= ", round(p_value, digits)),
-    p_value > .01 ~ stringr::str_c("= ", round(p_value, digits + 1)),
-    p_value > .001 ~ stringr::str_c("= ", round(p_value, digits + 2)),
-    p_value > .0001 ~ "< 0.001",
+    p_value > 0.1 ~ stringr::str_c("= ", round(p_value, digits)),
+    p_value > 0.05 ~ stringr::str_c("= ", round(p_value, digits)),
+    p_value > 0.01 ~ stringr::str_c("= ", round(p_value, digits + 1)),
+    p_value > 0.001 ~ stringr::str_c("= ", round(p_value, digits + 2)),
+    p_value > 0.0001 ~ "< 0.001",
     TRUE ~ "< 0.0001",
   )
 }

--- a/jarl.toml
+++ b/jarl.toml
@@ -1,0 +1,6 @@
+[lint]
+select = []
+ignore = []
+exclude = []
+default-exclude = true
+assignment = "<-"


### PR DESCRIPTION
This pull request introduces minor improvements and maintenance updates, focusing on code clarity and configuration. The most notable changes include refining assignment practices in R code, correcting p-value formatting logic, and adding configuration files for tooling.

**R code improvements:**

* Updated assignment style in `as_tidy_stat` to use explicit assignment (`res <- ...`) instead of the pipe assignment for clarity and consistency.

* Fixed the logic in `format_p` to use decimal notation (e.g., `0.1` instead of `.1`) for p-value thresholds, improving readability and reducing potential ambiguity.

**Tooling and configuration:**

* Added a `jarl.toml` configuration file with linting settings, specifying assignment style and default exclusions.
* Updated `.Rbuildignore` to exclude the new `jarl.toml` file from builds.